### PR TITLE
Bring rewriteArrayMethods files back

### DIFF
--- a/exercises/arrays/rewriteArrayMethods/README.md
+++ b/exercises/arrays/rewriteArrayMethods/README.md
@@ -1,0 +1,3 @@
+## Rewrite array methods
+
+Rewrite methods reduce and map.

--- a/exercises/arrays/rewriteArrayMethods/index.ts
+++ b/exercises/arrays/rewriteArrayMethods/index.ts
@@ -1,0 +1,28 @@
+const myMap = <TInput, TOutput>(
+	arr: TInput[],
+	callback: (item: TInput, index: number, arr: TInput[]) => TOutput,
+): TOutput[] => {
+	const resultArrMap = [];
+	for (let i = 0; i < arr.length; i++) {
+		const newItem = callback(arr[i], i, arr);
+		resultArrMap.push(newItem);
+	}
+	return resultArrMap;
+};
+
+const myReduce = <TInput, TOutput>(
+	arr: TInput[],
+	callback: (
+		acc: TOutput,
+		item: TInput,
+		index: number,
+		arr: TInput[],
+	) => TOutput,
+	initialValue: TOutput,
+): TOutput => {
+	let sum = initialValue;
+	for (let i = 0; i < arr.length; i++) {
+		sum = callback(sum, arr[i], i, arr);
+	}
+	return sum;
+};


### PR DESCRIPTION
1. I accidentally deleted the rewriteArrayMethods folder with files when I did 'git reset --hard <previous_commit>' to roll back previous changes.
2. After that, I moved these files back from another branch (I had a copy of the rewriteArrayMethods branch)